### PR TITLE
Move fetch result from ethereum out of start lifecyle #57

### DIFF
--- a/committee/committee.go
+++ b/committee/committee.go
@@ -105,7 +105,6 @@ type committee struct {
 	lastUpdateTimestamp int64
 	terminate           chan bool
 	mutex               sync.RWMutex
-	syncingChan         chan struct{}
 }
 
 // NewCommitteeWithKVStoreWithNamespace creates a committee with kvstore with namespace
@@ -209,11 +208,9 @@ func (ec *committee) Start(ctx context.Context) (err error) {
 				ec.terminate <- true
 				return
 			case height := <-heightChan:
-				ec.syncingChan <- struct{}{}
 				if err := ec.Sync(height); err != nil {
 					zap.L().Error("failed to sync", zap.Error(err))
 				}
-				<-ec.syncingChan
 			case err := <-reportChan:
 				zap.L().Error("something goes wrong", zap.Error(err))
 			}

--- a/committee/committee.go
+++ b/committee/committee.go
@@ -2,7 +2,7 @@
 // This program is free software: you can redistribute it and/or modify it under the terms of the
 // GNU General Public License as published by the Free Software Foundation, either version 3 of
 // the License, or (at your option) any later version.
-// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 // without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
 // the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with this program. If
@@ -261,9 +261,12 @@ func (ec *committee) fetchInBatchSplit(tipHeight uint64) error {
 			ec.currentHeight = tipHeight
 		}
 		results, errs := ec.fetchInBatch(ec.currentHeight)
+		ec.mutex.Lock()
 		if err := ec.storeInBatch(results, errs); err != nil {
+			ec.mutex.Unlock()
 			return errors.Wrap(err, "failed to catch up via network")
 		}
+		ec.mutex.Unlock()
 	}
 	return nil
 }
@@ -302,8 +305,6 @@ func (ec *committee) storeInBatch(
 	results map[uint64]*types.ElectionResult,
 	errs map[uint64]error,
 ) error {
-	ec.mutex.Lock()
-	defer ec.mutex.Unlock()
 	var heights []uint64
 	for height := range results {
 		heights = append(heights, height)

--- a/committee/committee.go
+++ b/committee/committee.go
@@ -2,7 +2,7 @@
 // This program is free software: you can redistribute it and/or modify it under the terms of the
 // GNU General Public License as published by the Free Software Foundation, either version 3 of
 // the License, or (at your option) any later version.
-// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 // without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
 // the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with this program. If
@@ -105,6 +105,7 @@ type committee struct {
 	lastUpdateTimestamp int64
 	terminate           chan bool
 	mutex               sync.RWMutex
+	syncingChan         chan struct{}
 }
 
 // NewCommitteeWithKVStoreWithNamespace creates a committee with kvstore with namespace
@@ -163,46 +164,44 @@ func NewCommittee(kvstore db.KVStore, cfg Config) (Committee, error) {
 		interval:              cfg.GravityChainHeightInterval,
 		currentHeight:         0,
 		nextHeight:            cfg.GravityChainStartHeight,
+		syncingChan:           make(chan struct{}, 1),
 	}, nil
 }
-
-func (ec *committee) Start(ctx context.Context) (err error) {
+func (ec *committee) load(ctx context.Context) (err error) {
 	ec.mutex.Lock()
 	defer ec.mutex.Unlock()
 	if err := ec.db.Start(ctx); err != nil {
 		return errors.Wrap(err, "error when starting db")
 	}
-	if startHeight, err := ec.db.Get(db.NextHeightKey); err == nil {
-		zap.L().Info("restoring from db")
-		ec.nextHeight = util.BytesToUint64(startHeight)
-		for height := ec.startHeight; height < ec.nextHeight; height += ec.interval {
-			zap.L().Info("loading", zap.Uint64("height", height))
-			data, err := ec.db.Get(ec.dbKey(height))
-			if err != nil {
-				return err
-			}
-			r := &types.ElectionResult{}
-			if err := r.Deserialize(data); err != nil {
-				return err
-			}
-			ec.cache.insert(height, r)
-			if err := ec.heightManager.add(height, r.MintTime()); err != nil {
-				return err
-			}
+	startHeight, err := ec.db.Get(db.NextHeightKey)
+	if err != nil {
+		return
+	}
+	zap.L().Info("restoring from db")
+	ec.nextHeight = util.BytesToUint64(startHeight)
+	for height := ec.startHeight; height < ec.nextHeight; height += ec.interval {
+		zap.L().Info("loading", zap.Uint64("height", height))
+		data, err := ec.db.Get(ec.dbKey(height))
+		if err != nil {
+			return err
+		}
+		r := &types.ElectionResult{}
+		if err := r.Deserialize(data); err != nil {
+			return err
+		}
+		ec.cache.insert(height, r)
+		if err := ec.heightManager.add(height, r.MintTime()); err != nil {
+			return err
 		}
 	}
-	zap.L().Info("catching up via network")
-	tipHeight, err := ec.carrier.TipHeight()
-	if err != nil {
-		return errors.Wrap(err, "failed to get tip height")
-	}
-	results, errs := ec.fetchInBatch(tipHeight)
-	if err := ec.storeInBatch(results, errs); err != nil {
-		return errors.Wrap(err, "failed to catch up via network")
-	}
+	return nil
+}
+func (ec *committee) Start(ctx context.Context) (err error) {
+	ec.load(ctx)
 	zap.L().Info("subscribing to new block")
 	heightChan := make(chan uint64)
 	reportChan := make(chan error)
+
 	go func() {
 		for {
 			select {
@@ -210,9 +209,11 @@ func (ec *committee) Start(ctx context.Context) (err error) {
 				ec.terminate <- true
 				return
 			case height := <-heightChan:
+				ec.syncingChan <- struct{}{}
 				if err := ec.Sync(height); err != nil {
 					zap.L().Error("failed to sync", zap.Error(err))
 				}
+				<-ec.syncingChan
 			case err := <-reportChan:
 				zap.L().Error("something goes wrong", zap.Error(err))
 			}
@@ -244,18 +245,33 @@ func (ec *committee) Status() STATUS {
 }
 
 func (ec *committee) Sync(tipHeight uint64) error {
-	results, errs := ec.fetchInBatch(tipHeight)
-	ec.mutex.Lock()
-	defer ec.mutex.Unlock()
-
-	return ec.storeInBatch(results, errs)
+	return ec.fetchInBatchSplit(tipHeight)
 }
-
+func (ec *committee) fetchInBatchSplit(tipHeight uint64) error {
+	zap.L().Info("new ethereum block", zap.Uint64("height", tipHeight))
+	fetchStart := ec.nextHeight + ec.interval
+	if tipHeight < fetchStart {
+		return nil
+	}
+	fetchHeight := uint64(ec.fetchInParallel) * ec.interval
+	for ec.currentHeight < tipHeight {
+		if ec.nextHeight+fetchHeight < tipHeight {
+			ec.currentHeight = ec.nextHeight + fetchHeight
+		} else {
+			ec.currentHeight = tipHeight
+		}
+		results, errs := ec.fetchInBatch(ec.currentHeight)
+		if err := ec.storeInBatch(results, errs); err != nil {
+			return errors.Wrap(err, "failed to catch up via network")
+		}
+	}
+	return nil
+}
 func (ec *committee) fetchInBatch(tipHeight uint64) (
 	map[uint64]*types.ElectionResult,
 	map[uint64]error,
 ) {
-	zap.L().Info("new ethereum block", zap.Uint64("height", tipHeight))
+	zap.L().Info("fetch new ethereum block", zap.Uint64("height", tipHeight))
 	if ec.currentHeight < tipHeight {
 		ec.currentHeight = tipHeight
 	}
@@ -286,6 +302,8 @@ func (ec *committee) storeInBatch(
 	results map[uint64]*types.ElectionResult,
 	errs map[uint64]error,
 ) error {
+	ec.mutex.Lock()
+	defer ec.mutex.Unlock()
 	var heights []uint64
 	for height := range results {
 		heights = append(heights, height)

--- a/committee/committee.go
+++ b/committee/committee.go
@@ -2,7 +2,7 @@
 // This program is free software: you can redistribute it and/or modify it under the terms of the
 // GNU General Public License as published by the Free Software Foundation, either version 3 of
 // the License, or (at your option) any later version.
-// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
 // without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
 // the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with this program. If

--- a/committee/committee.go
+++ b/committee/committee.go
@@ -163,7 +163,6 @@ func NewCommittee(kvstore db.KVStore, cfg Config) (Committee, error) {
 		interval:              cfg.GravityChainHeightInterval,
 		currentHeight:         0,
 		nextHeight:            cfg.GravityChainStartHeight,
-		syncingChan:           make(chan struct{}, 1),
 	}, nil
 }
 func (ec *committee) load(ctx context.Context) (err error) {


### PR DESCRIPTION
work on #57 
1. Avoid fetching and storing eth data in Start() to unblock blockchain server start earlier
2. Replacing batchFetch + batchStore with batchFetchAndStore to improve data availability latency
3. Avoid lock as much as possible to avoid blocking read APIs

This pr finished 1 and 2