### PR TITLE
Downgrade the logs of showing the invalid operator/reward address. #64

### DIFF
--- a/carrier/carrier.go
+++ b/carrier/carrier.go
@@ -2,7 +2,7 @@
 // This program is free software: you can redistribute it and/or modify it under the terms of the
 // GNU General Public License as published by the Free Software Foundation, either version 3 of
 // the License, or (at your option) any later version.
-// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
 // without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
 // the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with this program. If

--- a/carrier/carrier.go
+++ b/carrier/carrier.go
@@ -2,7 +2,7 @@
 // This program is free software: you can redistribute it and/or modify it under the terms of the
 // GNU General Public License as published by the Free Software Foundation, either version 3 of
 // the License, or (at your option) any later version.
-// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 // without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
 // the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with this program. If
@@ -96,7 +96,7 @@ func (evc *ethereumCarrier) BlockTimestamp(height uint64) (ts time.Time, err err
 			context.Background(),
 			big.NewInt(0).SetUint64(height),
 		); err == nil {
-			ts = time.Unix(int64(header.Time), 0)
+			ts = time.Unix(header.Time.Int64(), 0)
 			return
 		}
 		var rotated bool

--- a/carrier/carrier.go
+++ b/carrier/carrier.go
@@ -96,7 +96,7 @@ func (evc *ethereumCarrier) BlockTimestamp(height uint64) (ts time.Time, err err
 			context.Background(),
 			big.NewInt(0).SetUint64(height),
 		); err == nil {
-			ts = time.Unix(header.Time.Int64(), 0)
+			ts = time.Unix(int64(header.Time), 0)
 			return
 		}
 		var rotated bool

--- a/committee/committee.go
+++ b/committee/committee.go
@@ -11,6 +11,7 @@
 package committee
 
 import (
+	"bytes"
 	"context"
 	"math"
 	"math/big"
@@ -470,6 +471,16 @@ func (ec *committee) fetchResultByHeight(height uint64) (*types.ElectionResult, 
 	candidates, err := ec.fetchCandidatesByHeight(height)
 	if err != nil {
 		return nil, err
+	}
+	lenOfCandidates := len(candidates)
+	lenOfAddress := len(candidates[0].OperatorAddress())
+	empty := make([]byte, lenOfAddress)
+	for i := 0; i < lenOfCandidates; i++ {
+		if bytes.Equal(candidates[i].OperatorAddress(), empty) || bytes.Equal(candidates[i].RewardAddress(), empty) {
+			candidates = append(candidates[:i], candidates[i+1:]...)
+			lenOfCandidates--
+			i--
+		}
 	}
 	if err := calculator.AddCandidates(candidates); err != nil {
 		return nil, err


### PR DESCRIPTION
work on #64 

This problem cannot be avoid,because those candidates from ethereum as global info,
Error came from "operatorAddress":"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
or RewardAddress is empty,so I added a filter to delete empty candidate