### PR TITLE
Downgrade the logs of showing the invalid operator/reward address. #64

### DIFF
--- a/committee/committee.go
+++ b/committee/committee.go
@@ -11,6 +11,7 @@
 package committee
 
 import (
+	"bytes"
 	"context"
 	"math"
 	"math/big"
@@ -470,6 +471,16 @@ func (ec *committee) fetchResultByHeight(height uint64) (*types.ElectionResult, 
 	candidates, err := ec.fetchCandidatesByHeight(height)
 	if err != nil {
 		return nil, err
+	}
+	lenOfCandidates := len(candidates)
+	lenOfAddress := len(candidates[0].OperatorAddress())
+	empty := make([]byte, lenOfAddress)
+	for i := 0; i < lenOfCandidates; i++ {
+		if bytes.Equal(candidates[i].OperatorAddress(), empty) || bytes.Equal(candidates[i].RewardAddress(), empty) {
+			candidates = append(candidates[:i], candidates[i+1:]...)
+			lenOfCandidates--
+			i--
+		}
 	}
 	if err := calculator.AddCandidates(candidates); err != nil {
 		return nil, err


### PR DESCRIPTION
work on #64

This problem cannot be avoid,because those candidates from ethereum as global info,
Error came from "operatorAddress":"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
or RewardAddress is empty,so I added a filter to delete empty candidate