### PR TITLE
Move fetch result from ethereum out of start lifecyle #70

### DIFF
--- a/committee/committee.go
+++ b/committee/committee.go
@@ -2,7 +2,7 @@
 // This program is free software: you can redistribute it and/or modify it under the terms of the
 // GNU General Public License as published by the Free Software Foundation, either version 3 of
 // the License, or (at your option) any later version.
-// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
 // without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
 // the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with this program. If


### PR DESCRIPTION
work on #70 
1、Avoid fetching and storing eth data in Start() to unblock blockchain server start earlier
2、Replacing batchFetch + batchStore with batchFetchAndStore to improve data availability latency
Avoid lock as much as possible to avoid blocking read APIs