### PR TITLE
refactor committee

### DIFF
--- a/carrier/carrier_test.go
+++ b/carrier/carrier_test.go
@@ -2,7 +2,7 @@
 // This program is free software: you can redistribute it and/or modify it under the terms of the
 // GNU General Public License as published by the Free Software Foundation, either version 3 of
 // the License, or (at your option) any later version.
-// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 // without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
 // the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with this program. If
@@ -71,12 +71,12 @@ func TestVoteCarrier(t *testing.T) {
 		require.Equal(int64(1548986420), ts.Unix())
 	})
 	t.Run("SubscribeNewBlock", func(t *testing.T) {
-		heightChan := make(chan uint64)
+		tipChan := make(chan *TipInfo)
 		reportChan := make(chan error)
 		unsubscribe := make(chan bool)
-		carrier.SubscribeNewBlock(heightChan, reportChan, unsubscribe)
+		carrier.SubscribeNewBlock(tipChan, reportChan, unsubscribe)
 		select {
-		case <-heightChan:
+		case <-tipChan:
 			break
 		case err := <-reportChan:
 			require.NoError(err)

--- a/committee/heightmanager.go
+++ b/committee/heightmanager.go
@@ -2,7 +2,7 @@
 // This program is free software: you can redistribute it and/or modify it under the terms of the
 // GNU General Public License as published by the Free Software Foundation, either version 3 of
 // the License, or (at your option) any later version.
-// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 // without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
 // the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with this program. If
@@ -36,6 +36,7 @@ func (m *heightManager) nearestHeightBefore(ts time.Time) uint64 {
 	if m.times[0].After(ts) {
 		return 0
 	}
+
 	head := 0
 	tail := l
 	for {
@@ -52,7 +53,7 @@ func (m *heightManager) nearestHeightBefore(ts time.Time) uint64 {
 	return m.heights[head]
 }
 
-func (m *heightManager) lastestHeight() uint64 {
+func (m *heightManager) latestHeight() uint64 {
 	l := len(m.heights)
 	if l == 0 {
 		return 0

--- a/committee/heightmanager_test.go
+++ b/committee/heightmanager_test.go
@@ -2,7 +2,7 @@
 // This program is free software: you can redistribute it and/or modify it under the terms of the
 // GNU General Public License as published by the Free Software Foundation, either version 3 of
 // the License, or (at your option) any later version.
-// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 // without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
 // the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with this program. If
@@ -121,12 +121,12 @@ func TestNearestHeightBefore(t *testing.T) {
 	}
 }
 
-func TestLastestHeight(t *testing.T) {
+func TestLatestHeight(t *testing.T) {
 	require := require.New(t)
 	hm := newHeightManager()
 	for i, arg := range args {
 		// add and then check lastest height
 		require.NoError(hm.add(arg.height, arg.time))
-		require.Equal(args[i].height, hm.lastestHeight())
+		require.Equal(args[i].height, hm.latestHeight())
 	}
 }

--- a/votesync/votesync_test.go
+++ b/votesync/votesync_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/iotexproject/iotex-election/carrier"
 	"github.com/iotexproject/iotex-election/types"
 	"github.com/stretchr/testify/require"
 )
@@ -12,7 +13,7 @@ import (
 var cfg = Config{
 	OperatorPrivateKey:          "a000000000000000000000000000000000000000000000000000000000000000",
 	IoTeXAPI:                    "api.testnet.iotex.one:443",
-	VotingSystemContractAddress: "io1kep76e8z6xlcn6hr97wa7ykjnhfvz5uc3nlt5g",
+	VotingSystemContractAddress: "io1mxlycqanea52zskuquvun83pvvp28jn5kcz8vn",
 	GravityChainAPIs:            []string{"https://mainnet.infura.io/v3/b355cae6fafc4302b106b937ee6c15af"},
 	RegisterContractAddress:     "0x95724986563028deb58f15c5fac19fa09304f32d",
 	StakingContractAddress:      "0x87c9dbff0016af23f5b1ab9b8e072124ab729193",
@@ -57,9 +58,9 @@ func (*mockCarrier) BlockTimestamp(uint64) (time.Time, error) {
 	return time.Unix(1559240700, 0), nil
 }
 
-func (*mockCarrier) SubscribeNewBlock(chan uint64, chan error, chan bool) {}
+func (*mockCarrier) SubscribeNewBlock(chan *carrier.TipInfo, chan error, chan bool) {}
 
-func (*mockCarrier) TipHeight() (uint64, error) { return 0, nil }
+func (*mockCarrier) Tip() (*carrier.TipInfo, error) { return &carrier.TipInfo{}, nil }
 
 func (*mockCarrier) Candidates(uint64, *big.Int, uint8) (*big.Int, []*types.Candidate, error) {
 	return nil, nil, nil


### PR DESCRIPTION
1. Reenable catch up via network in go routine
2. Set last update time to latest tip block time
3. Make carrier return tip height and block time
4. Return 0 for HeightByTime if the latest block time is before the request time